### PR TITLE
Add '-x' flag which to extract code

### DIFF
--- a/Common/foiaPostInstall.sh
+++ b/Common/foiaPostInstall.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 # NB NB NB: There are tabs in this code. They MUST be kept.
 # Needs a parameter: instance name ($1)
+#  Modifications made to FOIA release:
+#
+#  S ^%ZIS(1,"G","SYS..|TNT|",22)="" -> Adds |TNT| device for all namespaces
+#  and points it to the IEN of the TELNET device
+#
+
+#  S XTV(8989.3,1,"XUCP")="N" -> Turns off "LOG RESOURCE USAGE" to prevent
+#  attempt to find ZOSVKR on GT.M
+#
+
+#  K ^XTV(8989.3,1,"DEV") -> Empties the "PRIMARY HFS DIR" which will let the
+#  ZGO routine write out the files in a temp dir that exists locally.
+#
+
 instance=$1
 ccontrol start CACHE
 csession CACHE -U $instance <<END
 
 S ^%ZIS(1,"G","SYS..|TNT|",22)=""
+S ^XTV(8989.3,1,"XUCP")="N"
 K ^XTV(8989.3,1,"DEV")
-
+END
 ccontrol stop CACHE quietly

--- a/Common/foiaPostInstall.sh
+++ b/Common/foiaPostInstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# NB NB NB: There are tabs in this code. They MUST be kept.
+# Needs a parameter: instance name ($1)
+instance=$1
+ccontrol start CACHE
+csession CACHE -U $instance <<END
+
+S ^%ZIS(1,"G","SYS..|TNT|",22)=""
+K ^XTV(8989.3,1,"DEV")
+
+ccontrol stop CACHE quietly

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Example:
 
     docker build --build-arg flags="-y -b -s -a https://github.com/OSEHRA/vxVistA-M/archive/master.zip" -t vxvista .
 
+##### available flags
+      -a    Alternate VistA-M repo (zip or git format) (Must be in OSEHRA format)
+      -r    Alternate VistA-M repo branch (git format only)
+      -b    Skip bootstrapping system (used for docker)
+      -c    Use Caché
+      -d    Create development directories (s & p) (GT.M and YottaDB only)
+      -e    Install QEWD (assumes development directories)
+      -m    Install Panorama (assumes development directories and QEWD)
+      -g    Use GT.M
+      -i    Instance name (Namespace/Database for Caché)
+      -p    Post install hook (path to script)
+      -s    Skip testing
+      -w    Install RPMS XINETD scripts
+      -y    Use YottaDB
+      -v    Build ViViaN Documentation
+      -x    Extract given M[UMPS] code (Caché only)
 ### entry
 Default: `/home`
 

--- a/README.md
+++ b/README.md
@@ -104,22 +104,7 @@ Example:
 
     docker build --build-arg flags="-y -b -s -a https://github.com/OSEHRA/vxVistA-M/archive/master.zip" -t vxvista .
 
-##### available flags
-      -a    Alternate VistA-M repo (zip or git format) (Must be in OSEHRA format)
-      -r    Alternate VistA-M repo branch (git format only)
-      -b    Skip bootstrapping system (used for docker)
-      -c    Use Caché
-      -d    Create development directories (s & p) (GT.M and YottaDB only)
-      -e    Install QEWD (assumes development directories)
-      -m    Install Panorama (assumes development directories and QEWD)
-      -g    Use GT.M
-      -i    Instance name (Namespace/Database for Caché)
-      -p    Post install hook (path to script)
-      -s    Skip testing
-      -w    Install RPMS XINETD scripts
-      -y    Use YottaDB
-      -v    Build ViViaN Documentation
-      -x    Extract given M[UMPS] code (Caché only)
+To see the flags that are available, execute the command 'autoInstaller.sh -h'
 ### entry
 Default: `/home`
 
@@ -159,6 +144,22 @@ Caché Install with local DAT file. You need to supply your own CACHE.DAT and CA
 
     docker build --build-arg flags="-c -b -s" --build-arg instance="cachevista" --build-arg postInstallScript="-p ./Common/pvPostInstall.sh" --build-arg entry="/opt/cachesys" -t cachevista .
     docker run -p 9430:9430 -p 8001:8001 -p2222:22 -p57772:57772 -d -P --name=cache cachevista
+
+
+Caché Install with local DAT file to stop after exporting the code from the Cache instance. You need to supply your own CACHE.DAT and CACHE.key and .tar.gz installer for RHEL.  These files need to be added to the cache-files directories.
+
+    docker build --build-arg flags="-c -b -x" --build-arg instance="cachevista" --build-arg postInstallScript="-p ./Common/foiaPostInstall.sh" --build-arg entry="/opt/cachesys" -t cachevista .
+    docker run -p 9430:9430 -p 8001:8001 -p2222:22 -p57772:57772 -d -P --name=cache cachevista
+
+To capture the exported code from the container and remove the Docker objects, execute the following commands:
+
+    docker cp cache:/opt/VistA-M /tmp/ # no need to put a cp -r
+    docker stop cache
+    docker rm cache
+    docker rmi cachevista
+
+A [volume](https://docs.docker.com/storage/volumes/) could also be mounted to the container.
+
 
 ### Building ViViaN and DOX with Docker
 

--- a/ViViaN/vivianInstall.sh
+++ b/ViViaN/vivianInstall.sh
@@ -13,7 +13,7 @@ usage()
 EOF
 }
 
-while getopts ":hi:s:" option
+while getopts ":h:x:i:s:" option
 do
     case $option in
         h)
@@ -25,6 +25,9 @@ do
             ;;
         i)
             instance=$(echo $OPTARG |tr '[:upper:]' '[:lower:]')
+            ;;
+        x)
+            extractOnly=$OPTARG
             ;;
     esac
 done
@@ -39,6 +42,9 @@ fi
 
 if [[ -z $scriptdir ]]; then
     scriptdir=/opt/vista
+fi
+if [[ -z $extractOnly ]]; then
+    extractOnly=false
 fi
 
 yum install -y httpd graphviz java-1.8.0-openjdk-devel php
@@ -119,6 +125,10 @@ echo "Ending VistAMComponentExtractor at:" $(timestamp)
 # echo "End of Log Dump"
 find ./VistA-M -type f -print0 | xargs -0 dos2unix > /dev/null 2>&1
 find ./VistA-M -type f -name "MPIPSIM*.m" -print0 | xargs -0 rm
+
+if $extractOnly; then
+  exit 0
+fi
 pushd VistA-docs
 cp $scriptdir/ViViaN/CMakeCache.txt /opt/VistA-docs
 /usr/bin/cmake .

--- a/ViViaN/vivianInstall.sh
+++ b/ViViaN/vivianInstall.sh
@@ -13,7 +13,7 @@ usage()
 EOF
 }
 
-while getopts ":h:x:i:s:" option
+while getopts ":h:xi:s:" option
 do
     case $option in
         h)
@@ -27,7 +27,7 @@ do
             instance=$(echo $OPTARG |tr '[:upper:]' '[:lower:]')
             ;;
         x)
-            extractOnly=$OPTARG
+            extractOnly=true
             ;;
     esac
 done

--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -481,7 +481,12 @@ if $installgtm || $installYottaDB; then
     chmod -R g+rw /home/$instance
 fi
 
+extract=""
+if $extractOnly; then
+  extract="-x"
+fi
+
 # Generate ViViaN Documentation
 if $generateViVDox; then
-    $scriptdir/ViViaN/vivianInstall.sh -i $instance -s $scriptdir -x "$extractOnly"
+    $scriptdir/ViViaN/vivianInstall.sh -i $instance -s $scriptdir $extract
 fi

--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -71,6 +71,7 @@ usage()
       -w    Install RPMS XINETD scripts
       -y    Use YottaDB
       -v    Build ViViaN Documentation
+      -x    Extract given M[UMPS] code
 
     NOTE:
     The Caché install only supports using .DAT files for the VistA DB, and
@@ -80,7 +81,7 @@ usage()
 EOF
 }
 
-while getopts ":ha:cbemdgi:vp:sr:wy" option
+while getopts ":ha:cbxemdgi:vp:sr:wy" option
 do
     case $option in
         h)
@@ -129,6 +130,10 @@ do
             ;;
         w)
             installRPMS=true
+            ;;
+        x)
+            generateViVDox=true
+            extractOnly=true
             ;;
         y)
             installYottaDB=true
@@ -191,6 +196,10 @@ fi
 
 if [ -z $generateViVDox ]; then
     generateViVDox=false;
+fi
+
+if [ -z $extractOnly ]; then
+    extractOnly=false;
 fi
 
 # Quit if no M environment viable
@@ -474,5 +483,5 @@ fi
 
 # Generate ViViaN Documentation
 if $generateViVDox; then
-    $scriptdir/ViViaN/vivianInstall.sh -i $instance -s $scriptdir
+    $scriptdir/ViViaN/vivianInstall.sh -i $instance -s $scriptdir -x "$extractOnly"
 fi


### PR DESCRIPTION
Add a '-x' flag which will utilize the ViViaN generation process but will
leave the execution after the export of the routines from the VistA
instance.  This directory can then be copied out of a container after it
has been initalized.