### PR TITLE
Add check to determine use of serial export

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Caché Install with local DAT file. You need to supply your own CACHE.DAT and CA
     docker run -p 9430:9430 -p 8001:8001 -p2222:22 -p57772:57772 -d -P --name=cache cachevista
 
 
-Caché Install with local DAT file to stop after exporting the code from the Cache instance. You need to supply your own CACHE.DAT and CACHE.key and .tar.gz installer for RHEL.  These files need to be added to the cache-files directories.
+Caché Install with local DAT file to stop after exporting the code from the Cache instance. You need to supply your own CACHE.DAT and .tar.gz installer for RHEL.
+When available, the system will also install a "cache.key" file when the system is built.  If it is not present, the extraction will be performed serially.
+These files need to be added to the cache-files directories.
 
     docker build --build-arg flags="-c -b -x" --build-arg instance="cachevista" --build-arg postInstallScript="-p ./Common/foiaPostInstall.sh" --build-arg entry="/opt/cachesys" -t cachevista .
     docker run -p 9430:9430 -p 8001:8001 -p2222:22 -p57772:57772 -d -P --name=cache cachevista

--- a/ViViaN/vivianInstall.sh
+++ b/ViViaN/vivianInstall.sh
@@ -94,6 +94,9 @@ VISTA_CACHE_NAMESPACE:STRING=$namespace" >> $scriptdir/ViViaN/CMakeCache.txt
   chown cacheusr$instance:cachegrp$instance $basedir/bin/start.sh
   chmod +x $basedir/bin/start.sh
   sh $basedir/bin/start.sh &
+  if [[ ! -f $basedir/mgr/cache.key ]]; then
+    serialExport="-sx"
+  fi
 fi
 
 # Add apache to start.sh
@@ -116,7 +119,7 @@ cp /opt/VistA/Packages.csv /opt/VistA-M/
 
 #  Export first so the configuration can find the correct files to query for
 echo "Starting VistAMComponentExtractor at:" $(timestamp)
-python /opt/VistA/Scripts/VistAMComponentExtractor.py $connectionArg -r /opt/VistA-M/ -o /tmp/ -l /tmp/
+python /opt/VistA/Scripts/VistAMComponentExtractor.py $connectionArg -r /opt/VistA-M/ -o /tmp/ -l /tmp/ $serialExport
 echo "Ending VistAMComponentExtractor at:" $(timestamp)
 # Uncomment to debug VistAMComponentExtractor
 # @TODO Make debugging a script option


### PR DESCRIPTION
Add a check to the pre-export section of the vivanInstall file which
looks for a cache.key file.  If it doesn't find one, it instructs the
export script to export serially instead of across multiple jobs.

Requires: http://review.code.osehra.org/#/c/1058/