### PR TITLE
Update YottaDB install version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yum  -y update && \
                    cmake \
                    dos2unix \
                    which \
+                   file \
                    unzip \
                    lsof \
                    net-tools \

--- a/GTM/install.sh
+++ b/GTM/install.sh
@@ -86,6 +86,12 @@ fi
 echo "Downloading ydbinstall"
 curl -s -L https://raw.githubusercontent.com/YottaDB/YottaDB/master/sr_unix/ydbinstall.sh -o ydbinstall
 
+isValidFile=`head ydbinstall | grep "Fidelity National Information"`
+if [[ ! $isValidFile ]]; then
+    echo "Something went wrong downloading ydbinstall"
+    exit $?
+fi
+
 # Get kernel.shmmax to determine if we can use 32k strings
 # ${#...} is to compare lengths of strings before trying to use them as numbers
 # Ubuntu 16.04 box seems to have a shared memory of 18446744073692774399!!!

--- a/GTM/install.sh
+++ b/GTM/install.sh
@@ -75,7 +75,7 @@ fi
 
 # YottaDB
 if [ $installYottaDB ] && [ -z $gtm_ver ]; then
-    gtm_ver="r1.10"
+    gtm_ver="r1.22"
 fi
 
 if [ -z $sharedmem ]; then
@@ -85,13 +85,6 @@ fi
 # Download ydbinstall
 echo "Downloading ydbinstall"
 curl -s -L https://raw.githubusercontent.com/YottaDB/YottaDB/master/sr_unix/ydbinstall.sh -o ydbinstall
-
-# Verify hash as we are going to make it executable
-sha1sum -c --status ydbinstall_SHA1
-if [ $? -gt 0 ]; then
-    echo "Something went wrong downloading ydbinstall"
-    exit $?
-fi
 
 # Get kernel.shmmax to determine if we can use 32k strings
 # ${#...} is to compare lengths of strings before trying to use them as numbers

--- a/GTM/ydbinstall_SHA1
+++ b/GTM/ydbinstall_SHA1
@@ -1,1 +1,0 @@
-e251bc174a860907dedb5209eb351fbfb9d6b45b  ydbinstall


### PR DESCRIPTION
With a recent update to the Yotta installer, 1.10 was no longer
available.  Update to a more recent version and ensure that a necessary
program is added.

To eliminate issues with a constantly updating file, remove the SHA1
check.