### PR TITLE
Adds the ability to autorelink routines by default

### DIFF
--- a/GTM/createVistaInstance.sh
+++ b/GTM/createVistaInstance.sh
@@ -221,7 +221,7 @@ chown $instance:$instance $basedir/etc/env
 echo "source $basedir/etc/env" >> $basedir/.bashrc
 
 # Setup base gtmroutines
-gtmroutines="\$basedir/r/\$gtmver(\$basedir/r)"
+gtmroutines="\$basedir/r/\$gtmver*(\$basedir/r)"
 
 # This block: Set gtmroutines
 # 64bit GT.M can use a shared library instead of $gtm_dist

--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -503,7 +503,7 @@ fi
 # Add p and s directories to gtmroutines environment variable
 if $developmentDirectories && ($installgtm || $installYottaDB); then
     su $instance -c "mkdir $basedir/{p,p/$gtmver,s,s/$gtmver}"
-    perl -pi -e 's#export gtmroutines=\"#export gtmroutines=\"\$basedir/p/\$gtmver\(\$basedir/p\) \$basedir/s/\$gtmver\(\$basedir/s\) #' $basedir/etc/env
+    perl -pi -e 's#export gtmroutines=\"#export gtmroutines=\"\$basedir/p/\$gtmver*\(\$basedir/p\) \$basedir/s/\$gtmver*\(\$basedir/s\) #' $basedir/etc/env
 fi
 
 # Install QEWD


### PR DESCRIPTION
What this does is this: if you edit a routine and have another process
open that may have used that routine in the past, doing a zlink in your
process will tell the other process to use that routine the moment it is
not on the stack of the other process.

Tested on VEHU6 instance.