### PR TITLE
Relinkctl files management & support

### DIFF
--- a/GTM/createVistaInstance.sh
+++ b/GTM/createVistaInstance.sh
@@ -156,6 +156,9 @@ echo ${instance}prog:prog | chpasswd
 # Make instance Directories
 su $instance -c "mkdir -p $basedir/{r,r/$gtmver,g,j,etc,etc/xinetd.d,log,tmp,bin,lib,www,backup}"
 
+# chmod instance directories to be readable by group
+su $instance -c "chmod g+rw $basedir/{r,r/$gtmver,g,j,etc,etc/xinetd.d,log,tmp,bin,lib,www,backup}"
+
 # Copy standard etc and bin items from repo
 su $instance -c "cp -R etc $basedir"
 su $instance -c "cp -R bin $basedir"
@@ -195,6 +198,7 @@ su $instance -c "ln -s $gtm_dist $basedir/lib/gtm"
 echo "export gtm_dist=$basedir/lib/gtm"         > $basedir/etc/env
 echo "export gtm_log=$basedir/log"              >> $basedir/etc/env
 echo "export gtm_tmp=$basedir/tmp"              >> $basedir/etc/env
+echo "export gtm_linktmpdir=$basedir/tmp"       >> $basedir/etc/env
 echo "export gtm_prompt=\"${instance^^}>\""     >> $basedir/etc/env
 echo "export gtmgbldir=$basedir/g/$instance.gld" >> $basedir/etc/env
 echo "export gtm_zinterrupt='I \$\$JOBEXAM^ZU(\$ZPOSITION)'" >> $basedir/etc/env

--- a/GTM/etc/init.d/vista
+++ b/GTM/etc/init.d/vista
@@ -49,6 +49,9 @@ start() {
     # Rundown readonly GT.M/YDB databases
     for f in $gtm_dist/*.dat; do $gtm_dist/mupip rundown -f $f; done
 
+    # Rundown relinkctl files
+    su $instance -c "source $basedir/etc/env && $gtm_dist/mupip rundown -relink"
+
     # Start TaskMan
     echo "Starting TaskMan"
     su $instance -c "source $basedir/etc/env && cd $basedir/tmp && $gtm_dist/mumps -run START^ZTMB"


### PR DESCRIPTION
- There is a bug in YDB r1.22/GTM 6.3/4 where relink ctrl files are not
stored properly in $gtm_tmp directory. We set gtm_linktmpdir to fix
that.
- Startup will now rundown relink files to prevent previous relink files
from interfering with operations.
- Permissions on directories in $basedir will be correct for group so
that initial relinkctl files will have the correct permission for group
so that tied and prog accounts would work.

Tested on: VEHU (GT.M no testing) and OSEHRA VistA (YottaDB with testing).