### PR TITLE
Add Synthea postInstall file

### DIFF
--- a/Common/syntheaPostInstall.sh
+++ b/Common/syntheaPostInstall.sh
@@ -4,7 +4,6 @@ pushd /tmp/loader
 # Download Synthea loader multibuild
 curl -fsSL --progress-bar https://github.com/OSEHRA/VistA-FHIR-Data-Loader/releases/download/0.1/VISTA_SYNTHETIC_DATA_LOADER_BUNDLE_0P2T1.KID.zip -o loader.zip
 unzip -q loader.zip -d /tmp/loader/Synthea
-popd
 echo "Installing Synthea ingestor patch"
 # Set up arguments for PatchSequenceApply scrip based upon system
 system=1
@@ -17,18 +16,15 @@ fi
 vistaDir="$basedir/Dashboard/VistA/Scripts"
 # But check to be sure and download VistA if necessary
 if [ ! -d $vistaDir ]; then
-  pushd /tmp/loader
   echo "Downloading OSEHRA VistA Tester Repo"
   curl -fsSL --progress-bar https://github.com/OSEHRA/VistA/archive/master.zip -o VistA-master.zip
   unzip -q VistA-master.zip
   rm VistA-master.zip
   mv VistA-master VistA
   vistaDir="/tmp/loader/VistA/Scripts"
-  popd
 fi
 # Installs as the DUZ=1 user
-pushd $vistaDir
 # Installs the single KIDS build for Synthea loader as DUZ=1 user.
-python PatchSequenceApply.py -S $system -p /tmp/loader/Synthea $instanceName -l /tmp/loader -i -n ALL -d 1
+python $vistaDir/PatchSequenceApply.py -S $system -p /tmp/loader/Synthea $instanceName -l /tmp/loader -i -n ALL -d 1
 popd
-rm -rf /tmp/loader
+rm -r /tmp/loader

--- a/Common/syntheaPostInstall.sh
+++ b/Common/syntheaPostInstall.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+mkdir /tmp/loader
+pushd /tmp/loader
+# Download Synthea loader multibuild
+curl -fsSL --progress-bar https://github.com/OSEHRA/VistA-FHIR-Data-Loader/releases/download/0.1/VISTA_SYNTHETIC_DATA_LOADER_BUNDLE_0P2T1.KID.zip -o loader.zip
+unzip -q loader.zip -d /tmp/loader/Synthea
+popd
+echo "Installing Synthea ingestor patch"
+# Set up arguments for PatchSequenceApply scrip based upon system
+system=1
+instanceName='-cn $instance'
+if ($installgtm || $installYottaDB); then
+  system=2
+  instanceName=''
+fi
+# Assume that '-s' was not supplied to Docker build
+vistaDir="$basedir/Dashboard/VistA/Scripts"
+# But check to be sure and download VistA if necessary
+if [ ! -d $vistaDir ]; then
+  pushd /tmp/loader
+  echo "Downloading OSEHRA VistA Tester Repo"
+  curl -fsSL --progress-bar https://github.com/OSEHRA/VistA/archive/master.zip -o VistA-master.zip
+  unzip -q VistA-master.zip
+  rm VistA-master.zip
+  mv VistA-master VistA
+  vistaDir="/tmp/loader/VistA/Scripts"
+  popd
+fi
+# Installs as the DUZ=1 user
+pushd $vistaDir
+# Installs the single KIDS build for Synthea loader as DUZ=1 user.
+python PatchSequenceApply.py -S $system -p /tmp/loader/Synthea $instanceName -l /tmp/loader -i -n ALL -d 1
+popd
+rm -rf /tmp/loader

--- a/GTM/etc/init.d/vista
+++ b/GTM/etc/init.d/vista
@@ -56,6 +56,13 @@ start() {
     echo "Starting TaskMan"
     su $instance -c "source $basedir/etc/env && cd $basedir/tmp && $gtm_dist/mumps -run START^ZTMB"
 
+    # Start M-Web-Server @ 9080
+    if [ -f $basedir/r/VPRJREQ.m ] || [ -f $basedir/p/VPRJREQ.m ]; then
+        echo "Starting M Web Server"
+        su $instance -c "source $basedir/etc/env && cd $basedir/tmp && $gtm_dist/mumps -r %XCMD 'D JOB^VPRJREQ(9080)'"
+    fi
+
+
     # Start PIP
     if [ -d $basedir/pip ] ; then
         echo "Starting PIP"


### PR DESCRIPTION
Add another command line argument which will allow the user to install
a version of the Synthea Ingestor patch using a supplied DUZ value as
the installer.

Add information about the DUZ that needs to be supplied.  **At this point,
it could be added as a command line value for FOIA based instances, where the install will work as user 17. 
 But, it will  not on a VEHU instance due to user 17 not existing.**