### PR TITLE
Redo post-install to fix/add various issues in ov6

### DIFF
--- a/Common/ov6pi.sh
+++ b/Common/ov6pi.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Postinstall for OSEHRA VistA Plan 6
-# See IMPORTANT notes in the .m file.
-cp ./Common/ov6piko.m $basedir/r/
-$gtm_dist/mumps -r ov6piko

--- a/Common/ov6piko.m
+++ b/Common/ov6piko.m
@@ -1,4 +1,4 @@
-ov6piko ; OSE/SMH - OSEHRA Korean VistA Post Install;2018-10-18  3:33 PM
+ov6piko ; OSE/SMH - OSEHRA Korean VistA Post Install;2019-04-22  9:50 AM
  ;
  ; *** IMPORTANT ***
  ; This .m file expects data produced by the OSEHRA testing framework.
@@ -27,9 +27,17 @@ users ; change user names
  d FILE^DIE(,"fda")
  ;
 patients ; change patient name
- n i,t,fda f i=1:1 s t=$p($t(ptdata+i),";;",2) q:t=""  d
+ n i,t,fda,DIERR f i=1:1 s t=$p($t(ptdata+i),";;",2) q:t=""  d
  . i $d(^DPT(i,0)) s fda(2,i_c,.01)=t
- d FILE^DIE(,"fda")
+ d FILE^DIE("E","fda")
+ i $D(DIERR) W "Error: " D MSG^DIALOG()
+ ;
+ ;
+kspLang ; change Kernel System Language to Korean
+ ; NB: This FDA syntax works only in FM22.2; don't try on FM22.0
+ S fda(8989.3,"1,","DEFAULT LANGUAGE")="KOREAN"
+ D FILE^DIE("E","fda")
+ i $D(DIERR) W "Error: " D MSG^DIALOG()
  quit
  ;
 ptdata ; data for patient names

--- a/Common/ov6piko.sh
+++ b/Common/ov6piko.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+mkdir /tmp/kids
+mkdir /tmp/kids/logs
+pushd /tmp/kids
+
+# Download KIDS build for Plan 6 Lexicon
+curl -sSOL https://github.com/OSEHRA-Sandbox/VistA-M/releases/download/kcd7/UKO_KCD7_LOAD_0p2.KID
+
+# Set up arguments for PatchSequenceApply script based upon system
+system=1
+instanceName='-cn $instance'
+if ($installgtm || $installYottaDB); then
+  system=2
+  instanceName=''
+fi
+
+# Assume that '-s' was not supplied to Docker build
+vistaDir="$basedir/Dashboard/VistA/Scripts"
+
+# But check to be sure and download VistA if necessary
+if [ ! -d $vistaDir ]; then
+  echo "Downloading OSEHRA VistA Tester Repo"
+  curl -fsSL --progress-bar https://github.com/OSEHRA/VistA/archive/master.zip -o VistA-master.zip
+  unzip -q VistA-master.zip
+  rm VistA-master.zip
+  mv VistA-master VistA
+  vistaDir="/tmp/kids/VistA/Scripts"
+fi
+
+# Installs as the DUZ=1 user
+python $vistaDir/PatchSequenceApply.py -S $system -p /tmp/kids $instanceName -l /tmp/kids/logs -i -n ALL -d 1
+popd
+rm -rf /tmp/kids
+
+# Postinstall for OSEHRA VistA Plan 6
+# See IMPORTANT notes in the .m file.
+cp ./Common/ov6piko.m $basedir/r/
+$gtm_dist/mumps -r ov6piko
+

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Default: "OSEHRA VistA (YottaDB, no bootstrap, with QEWD and Panorama)"
 
 Plan VI (Internationalized Version) OSEHRA VistA (YottaDB, UTF-8 enabled, no bootstrap, with QEWD and Panorama)
 
-    docker build --build-arg flags="-byuma https://github.com/OSEHRA-Sandbox/VistA-M/archive/plan-vi.zip -p ./Common/ov6pi.sh" --build-arg instance="ov6" -t ov6 .
+    docker build --build-arg flags="-byuma https://github.com/OSEHRA-Sandbox/VistA-M/archive/plan-vi.zip -p ./Common/ov6piko.sh" --build-arg instance="ov6" -t ov6 .
     docker run -d -p 2222:22 -p 8001:8001 -p 9430:9430 -p 8080:8080 -p 9080:9080 --name=ov6 ov6
 
 WorldVistA (YottaDB, Panorama, no boostrap, skip testing):

--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -529,6 +529,7 @@ fi
 
 # Post install hook
 if $postInstall; then
+  echo "Executing post install hook..."
   if $installgtm || $installYottaDB; then
     su $instance -c "source $basedir/etc/env && pushd $scriptdir && $postInstallScript && popd"
   elif $installcache; then


### PR DESCRIPTION
- Plan VI work modified menu strings, which breaks the Automated Testing
Framework. The solution is to revert back to English (done by a another
common in the VistA-M repo) & only set the language as the last step in
the post-install
- Now we can file Patient Names in External Format ("E" in FILE^DIE) as
the project fixed the input transform for entering a patient (File 2,
field .01)
- Post-installer installs Korean ICD-10, replacing the US version.
- Add an extra echo for post-install
- Rename post-installer to indicate it's Korea-specific