### PR TITLE
Recompile Routines on Plantium/FOIA

### DIFF
--- a/Common/pvPostInstall.sh
+++ b/Common/pvPostInstall.sh
@@ -4,6 +4,10 @@
 instance=$1
 ccontrol start CACHE
 csession CACHE -U $instance <<END
+; Recompile
+W "Recompiling Routines",!
+D Compile^%R("*.*")
+D Compile^%R("%*.*")
 ; Save pvPostInstall Routine
 W "Saving pvPostInstall...",!
 d \$SYSTEM.Process.SetZEOF(1)


### PR DESCRIPTION
Newer version of Cache means that routines no longer automatically run.