### PR TITLE
Fix setup of ViViaN docker container

### DIFF
--- a/ViViaN/CMakeCache.txt
+++ b/ViViaN/CMakeCache.txt
@@ -121,6 +121,9 @@ Java_JAVA_EXECUTABLE:FILEPATH=/bin/java
 //Use a local links for DOX page connections
 LOCAL_DOX_LINKS:BOOL=TRUE
 
+//A local ViViaN/files URL to point to
+LOCAL_VIVIAN_FILES_URL:STRING=http://localhost:3080/vivian/files
+
 //Command to build the project
 MAKECOMMAND:STRING=/usr/bin/gmake -i
 

--- a/ViViaN/vivianInstall.sh
+++ b/ViViaN/vivianInstall.sh
@@ -139,10 +139,10 @@ cp $scriptdir/ViViaN/CMakeCache.txt /opt/VistA-docs
 echo "Starting CTest at:" $(timestamp)
 echo "Installing XINDEX patch"
 /usr/bin/ctest -V -j $(grep -c ^processor /proc/cpuinfo) -R "XINDEX"
+echo "Executing XINDEX reports"
+/usr/bin/ctest -V -j $(grep -c ^processor /proc/cpuinfo) -R "CALLERGRAPH"
 echo "Executing data-gathering tasks"
-/usr/bin/ctest -V -j $(grep -c ^processor /proc/cpuinfo) -E "WebPageGenerator|FileManGlobalDataParser|XINDEX"
-echo "Parsing VistA Globals"
-/usr/bin/ctest -V -j $(grep -c ^processor /proc/cpuinfo) -R "FileManGlobalDataParser"
+/usr/bin/ctest -V -E "CALLERGRAPH|XINDEX|WebPageGenerator"
 echo "Generating ViViaN and DOX HTML"
 /usr/bin/ctest -V -j $(grep -c ^processor /proc/cpuinfo) -R "WebPageGenerator"
 echo "Ending CTest at:" $(timestamp)


### PR DESCRIPTION
* Set the default local ViViaN URL so the cmake step doesn't crash
* Change the ordering of the tests to ensure that the non-xindex ones
are run serially.  This is to prevent a dependency problem between those
tasks.