### PR TITLE
OTF changes broke stuff; fix it

### DIFF
--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -498,11 +498,18 @@ if (($installgtm || $installYottaDB) && ! $generateViVDox); then
       #
       su $instance -c "source $basedir/etc/env && mkdir -p $basedir/Dashboard"
       cd $basedir/Dashboard
+
+      echo "Installing pip"
+      curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+      python get-pip.py
+
       echo "Downloading OSEHRA VistA Tester Repo"
       curl -fsSL --progress-bar https://github.com/OSEHRA/VistA/archive/master.zip -o VistA-master.zip
+      #curl -fsSL --progress-bar https://github.com/josephsnyder/VistA/archive/master.zip -o VistA-master.zip # for testing only!
+      dir=$(zipinfo -1 VistA-master.zip | head -1 | cut -d/ -f1)
       unzip -q VistA-master.zip
       rm VistA-master.zip
-      mv VistA-master VistA
+      mv $dir VistA
       mv /usr/local/src/VistA-Source ./VistA-M
 
       # create random string for build identification


### PR DESCRIPTION
In the transition from Python 2 to Python 3, we are resiving some
scripts. One of the revisions is not to bundle pexpect, but rather
install it from pip. Therefore, we need pip. This commit adds pip to the
CentOS install; plus we slightly change the way we unzip the OTF repo in
order to allow us to use a different repo if we want.