### PR TITLE
Remove relink control files

### DIFF
--- a/GTM/etc/init.d/vista
+++ b/GTM/etc/init.d/vista
@@ -49,8 +49,8 @@ start() {
     # Rundown readonly GT.M/YDB databases
     for f in $gtm_dist/*.dat; do $gtm_dist/mupip rundown -f $f; done
 
-    # Rundown relinkctl files
-    su $instance -c "source $basedir/etc/env && $gtm_dist/mupip rundown -relink"
+    # Remove relinkctl files
+    su $instance -c "source $basedir/etc/env && rm -f $basedir/tmp/*relink*"
 
     # Start TaskMan
     echo "Starting TaskMan"


### PR DESCRIPTION
Running down the relink control files doesn't always allow rocto, etc
to run. Instead of running them down on start up, just remove them.