### PR TITLE
Update the ICR file download

### DIFF
--- a/ViViaN/vivianInstall.sh
+++ b/ViViaN/vivianInstall.sh
@@ -106,7 +106,7 @@ mkdir -p /opt/VistA-docs
 mkdir -p /opt/viv-out
 pushd /opt
 echo "Acquiring DBIA/ICR Information from https://foia-vista.osehra.org/VistA_Integration_Agreement/"
-curl -fsSL --progress-bar https://foia-vista.osehra.org/VistA_Integration_Agreement/2019_January_24_IA_Listing_Descriptions.TXT -o ICRDescription.txt
+curl -fsSL --progress-bar https://foia-vista.osehra.org/VistA_Integration_Agreement/2019_September_10_IA_Listing_Descriptions.TXT -o ICRDescription.txt
 echo "Downloading OSEHRA VistA Testing Repository"
 curl -fsSL --progress-bar https://github.com/OSEHRA/VistA/archive/master.zip -o VistA-master.zip
 unzip -q VistA-master.zip


### PR DESCRIPTION
Update the ICR file that is downloaded for inclusion with the ViViaN and
DOX data to be the latest version.  This version is from September 10th,
2019 and is availabe from foia-vista.osehra.org