### PR TITLE
Change Dockerfile to specify CentOS 7 instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 RUN echo "multilib_policy=best" >> /etc/yum.conf
 RUN yum update  -y && \


### PR DESCRIPTION
CentOS 8 has different package names thus the out of the box
Dockerfile for CentOS 7 doesn't work on CentOS 8.