### PR TITLE
YottaDB GUI update, Rocky version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8.7
+FROM rockylinux:8.8
 
 RUN echo "multilib_policy=best" >> /etc/yum.conf
 RUN yum update  -y && \

--- a/GTM/createVistaInstance.sh
+++ b/GTM/createVistaInstance.sh
@@ -223,11 +223,13 @@ echo "source $basedir/etc/env" >> $basedir/.bashrc
 gtmroutines="\$basedir/r/\$gtmver*(\$basedir/r)"
 
 # This block: Set gtmroutines
+# Include Posix as that's required by Octo and GUI
 if $utf8; then
-  echo "export gtmroutines=\"$gtmroutines $basedir/lib/gtm/utf8/libgtmutil.so $basedir/lib/gtm/utf8\"" >> $basedir/etc/env
+  echo "export gtmroutines=\"$gtmroutines $basedir/lib/gtm/plugin/o/utf8/_ydbposix.so $basedir/lib/gtm/utf8/libgtmutil.so\"" >> $basedir/etc/env
 else
-  echo "export gtmroutines=\"$gtmroutines $basedir/lib/gtm/libgtmutil.so $basedir/lib/gtm\"" >> $basedir/etc/env
+  echo "export gtmroutines=\"$gtmroutines $basedir/lib/gtm/plugin/o/_ydbposix.so $basedir/lib/gtm/libgtmutil.so\"" >> $basedir/etc/env
 fi #utf8
+echo "export GTMXC_ydbposix=\"$gtm_dist/plugin/ydbposix.xc\"" >> $basedir/etc/env
 
 # This block: Set utf-8 variables
 # LC_ALL & LC_LANG get set to C for a lot of time. We need these here.

--- a/GTM/etc/init.d/ydbgui
+++ b/GTM/etc/init.d/ydbgui
@@ -44,7 +44,7 @@ export PATH=$PATH:/usr/local/bin
 # Start YottaDB GUI @ 8089
 start() {
     echo  "Starting YottaDB GUI"
-    su - $instance -c "$gtm_dist/yottadb -run ^%ydbgui --port 8089 --readwrite > $basedir/log/ydbgui.log 2>&1 &"
+    su - $instance -c "$gtm_dist/yottadb -run ^%ydbgui --port 8089 --auth-file /home/foia/etc/users.json > $basedir/log/ydbgui.log 2>&1 &"
 }
 
 # Stop YottaDB GUI 

--- a/GTM/install.sh
+++ b/GTM/install.sh
@@ -107,23 +107,13 @@ else
     gtm_arch=$arch
 fi
 
-# Install requirements for Octo
-yum --enablerepo=powertools install -y cmake vim-common bison flex readline-devel libconfig-devel openssl-devel
+# Install requirements for YDB Source/Octo/YDBGUI
+yum --enablerepo=powertools install -y cmake vim-common bison flex readline-devel libconfig-devel openssl-devel epel-release tcsh ncurses-devel elfutils-libelf-devel
+yum install -y libsodium-devel # Must install epel-release first
 
 # Download ydbinstall
 if $source; then
     if $installYottaDB; then
-       yum install -y \
-                    git \
-                    gcc \
-                    make \
-                    cmake \
-                    tcsh \
-                    libconfig \
-                    libicu-devel \
-                    ncurses-devel \
-                    elfutils-libelf-devel \
-                    binutils-devel
         git clone https://gitlab.com/YottaDB/DB/YDB.git
         cd YDB
         mkdir build
@@ -132,7 +122,7 @@ if $source; then
         make -j `grep -c ^processor /proc/cpuinfo`
         make install
         cd yottadb_r*
-        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch"
+        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch"
     else
         echo "Installing GT.M from source isn't supported"
         exit 1
@@ -155,7 +145,7 @@ else
     #                     this follows VistA convention of uppercase only routines
     # Force install is necessary b/c of a recent change in the YDB installer.
     if [ "$installYottaDB" = "true" ] ; then
-        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
+        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
     else
         ./ydbinstall --force-install --gtm --ucaseonly-utils --utf8 default --installdir /opt/lsb-gtm/"$gtm_ver"_"$gtm_arch" $gtm_ver
     fi

--- a/GTM/installOcto.sh
+++ b/GTM/installOcto.sh
@@ -63,8 +63,7 @@ echo "Done Creating Octo and AIM databases"
 
 # Add additional Octo items to env script
 cat <<EOF >> $basedir/etc/env
-export gtmroutines="\$gtmroutines $gtm_dist/plugin/o/_ydbocto.so $gtm_dist/plugin/o/_ydbposix.so $gtm_dist/plugin/o/_ydbaim.so"
-export GTMXC_ydbposix="$gtm_dist/plugin/ydbposix.xc"
+export gtmroutines="\$gtmroutines $gtm_dist/plugin/o/_ydbocto.so $gtm_dist/plugin/o/_ydbaim.so"
 EOF
 
 echo "Creating admin:admin Octo user"

--- a/GTM/installYottaDBGUI.sh
+++ b/GTM/installYottaDBGUI.sh
@@ -57,27 +57,24 @@ do
     esac
 done
 
-if [[ -z $firewall ]]; then
+if [ -z $firewall ]; then
     firewall=true
 fi
-
-# Get code, build, install
-mkdir /tmp/ydbgui
-cd /tmp/ydbgui
-wget https://gitlab.com/YottaDB/UI/YDBGUI/-/archive/master/YDBGUI-master.zip -O YDBGUI.zip
-#wget https://gitlab.com/shabiel/YDBGUI/-/archive/ydbgui-install/YDBGUI-ydbgui-install.zip -O YDBGUI.zip
-dir=$(zipinfo -1 YDBGUI.zip | head -1 | cut -d/ -f1)
-unzip YDBGUI.zip
-mv $dir YDBGUI
-mkdir YDBGUI/build && cd YDBGUI/build
-cmake .. && make VERBOSE=1 && make install
-cd /tmp/
-rm -rf /tmp/ydbgui
 
 # Add additional YDBGUI items to env script
 cat <<EOF >> $basedir/etc/env
 export gtmroutines="\$gtmroutines /home/vehu/lib/gtm/plugin/o/_ydbgui.so /home/vehu/lib/gtm/plugin/o/_ydbmwebserver.so"
 EOF
+
+# Add users for the GUI
+cat <<EOF >> $basedir/etc/users.json
+[{
+	"username": "admin",
+	"password": "admin",
+	"authorization": "RW"
+}]
+EOF
+chown $instance:$instance $basedir/etc/users.json
 
 # Modify init.d scripts to reflect $instance
 perl -pi -e 's#/home/foia#'$basedir'#g' $basedir/etc/init.d/ydbgui


### PR DESCRIPTION
- Rocky Linux 8.7 -> 8.8
- Set Posix environment variables in one place (as it's required by both GUI and Octo)
- Install GUI with user login using `ydbinstall.sh`; remove manual install.
- Start-up GUI with users
- Small refactoring ([[ -> [, unify as much as possible on a single yum install)