### PR TITLE
[YDB#1080] Add libcurl-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN yum update  -y && \
                    xinetd \
                    perl \
                    curl \
+                   libcurl-devel \
                    python3 \
                    openssh-server \
                    openssh-clients \

--- a/autoInstaller.sh
+++ b/autoInstaller.sh
@@ -337,6 +337,7 @@ if $bootstrap; then
                        xinetd \
                        perl \
                        curl \
+		       libcurl-devel \
                        python \
                        openssh-server \
                        openssh-clients \


### PR DESCRIPTION
Background
----------
* The `docker-vista-amd64` pipeline job [failed](https://gitlab.com/YottaDB/DBMS/YDBOcto/-/jobs/7042468681) in the YDBOcto project with the following error.

  ``` #22 148.2 Header file(s) required by selected plugins not found: curl/curl.h #22 148.2 YottaDB installation aborted due to above error. Run ydbinstall --help for detailed option list #22 ERROR: process "/bin/sh -c ./autoInstaller.sh ${install_flags}" did not complete successfully: exit code: 1 ------
   > [18/18] RUN ./autoInstaller.sh -o -f -b -s -q -d -n -a https://github.com/WorldVistA/VistA-VEHU-M/archive/master.zip -i vehu:
   .
   .
  ------ Dockerfile:83 --------------------
    81 |         dos2unix /opt/vista/ViViaN/* >/dev/null 2>&1
    82 |
    83 | >>> RUN ./autoInstaller.sh ${install_flags}
    84 |     ENTRYPOINT ${entry_path}/bin/start.sh
    85 |     EXPOSE 22 8001 9100 9101 61012 9430 8080 8081 8089 9080 57772 5001
  ```

* The issue is the absence of `curl/curl.h`.

Issue
-----
* See https://gitlab.com/YottaDB/DB/YDB/-/merge_requests/1535 for problem cause and fix.

* In that case, the fix was to follow the package name listed in the `For Ubuntu/Debian` section of https://gitlab.com/YottaDB/Util/YDBCurl#prerequisites.

Fix
---
* In this case though, `autoInstaller.sh` uses Rocky Linux (not Debian) so we need to follow the `For Rocky Linux` section of the same url.

* That lists `libcurl-devel` as the package needed for `curl.h`. So this commit adds that package to the list of installed packages in `autoInstaller.sh`. While at that, noticed that `Dockerfile` also has a similar issue so fixed that as well.