### PR TITLE
[#77] GUI TLS support

### DIFF
--- a/GTM/etc/init.d/ydbgui
+++ b/GTM/etc/init.d/ydbgui
@@ -43,14 +43,20 @@ export PATH=$PATH:/usr/local/bin
 
 # Start YottaDB GUI @ 8089
 start() {
-    echo  "Starting YottaDB GUI"
-    su - $instance -c "$gtm_dist/yottadb -run ^%ydbgui --port 8089 --auth-file /home/foia/etc/users.json > $basedir/log/ydbgui.log 2>&1 &"
+    echo  "Starting YottaDB GUI on HTTP at 8089"
+    su - $instance -c "$gtm_dist/yottadb -run ^%ydbgui --port 8089 --auth-file /home/foia/etc/users.json > $basedir/log/ydbgui-http.log 2>&1 &"
+    echo  "Starting YottaDB GUI on HTTPS at 8091"
+    su - $instance -c "$gtm_dist/yottadb -run ^%ydbgui --tlsconfig ydbgui --port 8091 --auth-file /home/foia/etc/users.json > $basedir/log/ydbgui-https.log 2>&1 &"
 }
 
 # Stop YottaDB GUI 
 stop() {
-    echo "Stopping YottaDB GUI"
+    export USER=$instance
+    export ydb_tls_passwd_ydbgui="$(echo ydbgui | $gtm_dist/plugin/gtmcrypt/maskpass | cut -d ":" -f2 | tr -d '[:space:]')"
+    echo "Stopping YottaDB GUI on HTTP at 8089"
     su - $instance -c "$gtm_dist/yottadb -run stop^%ydbgui --port 8089"
+    echo "Stopping YottaDB GUI on HTTP at 8091"
+    su - $instance -c "$gtm_dist/yottadb -run stop^%ydbgui --tlsconfig client --port 8091"
 }
 
 case "$1" in

--- a/GTM/install.sh
+++ b/GTM/install.sh
@@ -108,7 +108,7 @@ else
 fi
 
 # Install requirements for YDB Source/Octo/YDBGUI
-yum --enablerepo=powertools install -y cmake vim-common bison flex readline-devel libconfig-devel openssl-devel epel-release tcsh ncurses-devel elfutils-libelf-devel gawk libgcrypt-devel nodejs
+yum --enablerepo=powertools install -y cmake vim-common bison flex readline-devel libconfig-devel openssl-devel epel-release tcsh ncurses-devel elfutils-libelf-devel gawk libgcrypt-devel nodejs gpgme-devel
 yum install -y libsodium-devel # Must install epel-release first
 
 # Download ydbinstall
@@ -118,11 +118,11 @@ if $source; then
         cd YDB
         mkdir build
         cd build
-        cmake -D CMAKE_INSTALL_PREFIX:PATH=$PWD ../
-        make -j `grep -c ^processor /proc/cpuinfo`
+        cmake ..
+	make -j $(($(getconf _NPROCESSORS_ONLN) - 1))
         make install
         cd yottadb_r*
-        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch"
+        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --encplugin --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch"
     else
         echo "Installing GT.M from source isn't supported"
         exit 1
@@ -145,7 +145,7 @@ else
     #                     this follows VistA convention of uppercase only routines
     # Force install is necessary b/c of a recent change in the YDB installer.
     if [ "$installYottaDB" = "true" ] ; then
-        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
+        ./ydbinstall --force-install --ucaseonly-utils --utf8 default --octo --gui --encplugin --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
     else
         ./ydbinstall --force-install --gtm --ucaseonly-utils --utf8 default --installdir /opt/lsb-gtm/"$gtm_ver"_"$gtm_arch" $gtm_ver
     fi


### PR DESCRIPTION
- GUI starts on port 8089 for HTTP (web socket at 8090)
- GUI starts on port 8091 for HTTPS (web socket at 8091)
- Encryption plugin needs now to be installed and certificates need to be set-up.